### PR TITLE
Don't scrape init container on Prometheus and Alertmanager

### DIFF
--- a/monitoring/templates/alertmanager/monitor.yaml
+++ b/monitoring/templates/alertmanager/monitor.yaml
@@ -18,12 +18,3 @@ spec:
           secret:
             name: local-trust-bundle
             key: ca.crt
-    - path: /metrics
-      port: reloader-web
-      scheme: https
-      tlsConfig:
-        serverName: {{ include "alertmanager.hostname.short" . | quote }}
-        ca:
-          secret:
-            name: local-trust-bundle
-            key: ca.crt


### PR DESCRIPTION
The scrape target for the `reloader-web` container is also targeting the init container, which gets marked as down once it is completed. So disable targeting that endpoint.